### PR TITLE
BRMS-78: Add second argument to authentication and match response

### DIFF
--- a/app/uk/gov/hmrc/brm/connectors/BirthConnector.scala
+++ b/app/uk/gov/hmrc/brm/connectors/BirthConnector.scala
@@ -142,7 +142,7 @@ trait BirthConnector extends ServicesConfig {
       )
     )
 
-    metrics.endTimer(startTime)
+    metrics.endTimer(startTime, "authentication-timer")
 
     body(handleResponse(response, extractAccessToken, "requestAuth"))
   }
@@ -159,7 +159,7 @@ trait BirthConnector extends ServicesConfig {
             Logger.info(s"[BirthConnector][requestReference]: $eventEndpoint")
             val response = httpClient.get(s"$eventEndpoint/$reference", Headers.apply(GROEventHeaderCarrier(x.as[String])))
 
-            metrics.endTimer(startTime)
+            metrics.endTimer(startTime, "reference-match-timer")
 
             handleResponse(response, extractJson, "requestReference")
 


### PR DESCRIPTION
@adamconder @manishsw 

Response logs not getting created in Grafana was due to second argument not being included.