### PR TITLE
Setting http proxy to None

### DIFF
--- a/app/uk/gov/hmrc/brm/tls/TLSFactory.scala
+++ b/app/uk/gov/hmrc/brm/tls/TLSFactory.scala
@@ -97,7 +97,8 @@ trait TLSFactory {
       connectTimeout = connectionTimeout,
       readTimeout = readTimeout,
       sslSocketFactory = sslSocketFactory,
-      hostnameVerifier = hostnameVerifier
+      hostnameVerifier = hostnameVerifier,
+      proxy = None // Do not provide a proxy object as these are set via system properties -Dhttp.proxyHost etc
     )
   }
 


### PR DESCRIPTION
Setting None for the Proxy as the values will be provided by system properties -Dhttp.proxyHost etc