### PR TITLE
[DDCE-1869][EH] Added x-correlation-id to outbound requests

### DIFF
--- a/app/uk/gov/hmrc/brm/connectors/GROEnglandAndWalesConnector.scala
+++ b/app/uk/gov/hmrc/brm/connectors/GROEnglandAndWalesConnector.scala
@@ -78,7 +78,7 @@ class GROEnglandAndWalesConnector @Inject()(groConfig: GroAppConfig,
     val headers = groHeaderCarrier(token)
     metrics.requestCount() // increase counter for attempt to gro reference
 
-    debug(CLASS_NAME, "getChildByReference", s"$endpoint/$reference headers: $headers")
+    debug(CLASS_NAME, "getChildByReference", s"$endpoint/$reference headers: $headers ${hc.extraHeaders}")
     info(CLASS_NAME, "getChildByReference", s"requesting child's details $endpoint")
 
     val startTime = metrics.startTimer()
@@ -101,7 +101,7 @@ class GROEnglandAndWalesConnector @Inject()(groConfig: GroAppConfig,
     val headers = groHeaderCarrier(token)
     metrics.requestCount("details-request") // increase counter for attempt to gro details
 
-    debug(CLASS_NAME, "getChildByDetails", s"$endpoint/ headers: $headers")
+    debug(CLASS_NAME, "getChildByDetails", s"$endpoint/ headers: $headers ${hc.extraHeaders}")
     info(CLASS_NAME, "getChildByDetails", s"requesting child's details $endpoint")
 
     val startTime = metrics.startTimer()


### PR DESCRIPTION
# DDCE-1869

Added x-correlation-id to outbound requests. Attempt to retrieve upstream request x-correlation-id, otherwise generate a new one before adding to the HeaderCarrier extraHeaders seq.

## Checklist PR Raiser
- [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
- [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
- [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
- [x]  I've squashed my commits - including the JIRA issue number in the commit message
- [ ]  I've run a dependency check to ensure all dependencies are up to date