### PR TITLE
[DDCE-5592] Config refactor for moving to new keystore standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ tmp
 .idea_modules
 bin
 .bsp
+.metals
+.vscode
+conf/cert

--- a/app/uk/gov/hmrc/brm/config/CustomWSConfigParser.scala
+++ b/app/uk/gov/hmrc/brm/config/CustomWSConfigParser.scala
@@ -61,6 +61,7 @@ class CustomWSConfigParser @Inject() (configuration: Configuration, env: Environ
     wsClientConfig
   }
 
+  //TODO remove this below and clean up above after DDCE-5592 5593 and 5594 are complete. Also clean up configs
   /**
     * @return absolute file path with the bytes written to the file
     */

--- a/app/uk/gov/hmrc/brm/config/GroAppConfig.scala
+++ b/app/uk/gov/hmrc/brm/config/GroAppConfig.scala
@@ -40,7 +40,7 @@ class GroAppConfig @Inject() (val servicesConfig: ServicesConfig) {
   lazy val authenticationUri: String = servicesConfig.getString(s"microservice.services.$authenticationConfigPath.uri")
 
   lazy val tlsPrivateKeystore: String    = servicesConfig.getString(s"$tlsConfigPath.privateKeystore")
-  lazy val tlsPrivateKeystoreKey: String = servicesConfig.getString(s"$tlsConfigPath.privateKeystoreKey")
+  lazy val tlsPrivateKeystorePassword: String = servicesConfig.getString(s"$tlsConfigPath.privateKeystorePassword")
   lazy val certificateExpiryDate: String = servicesConfig.getString(s"$tlsConfigPath.certificateExpiryDate")
   lazy val tlsEnabled: Boolean           = servicesConfig.getBoolean(s"$tlsConfigPath.tlsEnabled")
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -26,7 +26,7 @@ play.modules.enabled += "uk.gov.hmrc.brm.config.ModuleBindings"
 play.modules.enabled += "uk.gov.hmrc.brm.config.CustomWSConfigParserModule"
 
 play.modules.disabled += "play.api.libs.ws.ahc.AhcWSModule"
-play.modules.enabled += "uk.gov.hmrc.brm.http.CustomAhcWSModule"
+play.modules.enabled  += "uk.gov.hmrc.brm.http.CustomAhcWSModule"
 
 # Session Timeout
 # ~~~~
@@ -108,7 +108,6 @@ microservice {
         proxy {
             http.password = squiduser
             proxyRequiredForThisEnvironment = false
-
             username = squiduser
             password = ${microservice.services.proxy.http.password}
             protocol = http
@@ -121,12 +120,19 @@ microservice {
             gro  {
 
                 tls {
+                    //if you wish to enable tls for local testing you must generate a certificate in .p12 format with the below password and place it in the conf/cert folder
                     tlsEnabled = false
-
-                    //these keys are dummy values, not used in any environments, kept here for local testing
+                    //these keys are dummy values which are overidden in environments
                     privateKeystore = """/u3+7QAAAAIAAAABAAAAAQADYnJtAAABd2ONqqcAAAmHMIIJgzAOBgorBgEEASoCEQEBBQAEgglv11/As7q07kx61apMFyRf5mv/erPaq6S2k9bg2yTbzBTUamj310LQe/QTYxkoL6vQmKHdbUbCcYF1bi8hfRn+0uQiww/mRGFNaFpRQkJELkJSKI03P689Ru9l0LLTBJCw1HfshjTT0To8EHD/TadYjP/kxPac6V4Ct5l4jcjFO9CcOGou4FkLzMoRoh3y8lSv7bVg71aqIFlsyhhdMZxoO1Gtw3eULrixQQRRmCKCgwP5U3GUt/N8AB2N+iaZnc6V5uFyFIoDla46jatsTmVmajz52SZZuIl/UTIoASIUJre1ln1VYMSJn2PP7Bf+Xg6A73/dADMK9h+S52p/r8oY0kc7zVC8QJQi+zKjFcY3f8ctqM4TMg32rpZ3UX5fO4KB0ec530sHmYhoq8dNes5F2nu0jUL9hGAojsVNrqYYBn3F0ZkMASVC0AdP+I8Q14skeB/mp7ESpMkGaLQ7K2o+uOg4q4B6AOXVoF+MbAJs4wTGnFb3/9C5Y5e8bSpHbOasQ6dzRzPcUBAhpVTA9Sj2EQNwJ2GlcGcaEAI0t8GgBcEncWMMqd6vkn6szOEHtIsL0Q3NmZc/+sEtWah/p1BhnuPhSU5RB5AtpmQi2TGLbW/UWo4aU36vzNuq4r4zjF9UTwhCY7WNSnj09mEvErhVnRAkYOiKcbsq2YKP8aHTk1eYL1jDML78ULx7g1guliRsSpzkZ1LVyyoUgDdLdKfDbyJr2R/AiQzIkTnQrIMtemz/h+YHHsAvOM3Sl3xHNaEQ24Quke5+AAAjLOZoyetVg3hXaIXUIX0nSaZHDvCYPK3CwKAdz1KXiIxjCUHiT1qGyzg7/GtW5wd0ZEClGc2d2U98ZQm+e8JDXWNVSeFrOL9z3CaAn/qog0Hbo7wHpr595iAWYbiyGqSu6sU5qMLl3Ci7FSHRxY9c2Ess05vUuy0MvfkRnlBp6oNZCZjwpiH4Au1bL3i8wb6EKi+twkvUXr2QuOrm24N5CVqystgG9woF0enzadeQOSkL1o7c7zB1XgKYcV9QPgB/0TFSXKTUz+jwiTFrgW7dARLnXyGiAHDhjcH10yfyEjW2ilfUxL75yvUA7CTzi15muas2jKK5qeb4t+SN9x7EEknfS4usCNBXkzFjEjX+GUw9dHEVYYN9QnPE3Qbotg0LXHqTxNY0UDkjUgQeyR4KRJVazABJjgDxNQlPWZA7C3HlhNCeOcEhJvf5GI+K+XVYIgQ35iGHGrot3cB5QOHNyX3XUNaTUSSQ6g4EzhJLVaQl2BxYwZc7Ltfew9IajhFFtVAnnXH8iZwNme3m93q0+hmIBmghQBNMjF+L/uouBvgukWeSwvWQacgvdlWMnxwi63v6y/NxNPdPxhPu/exSjqoHKK0hfmluYZOvqu7K6XMdy416N3vrJuYBFc44CHuh4fiDPe/chkYIUG2Bjf65Yapr12rATi7lnOKN7rpsjWexm7+ArlhMNpzGzhIxScqsylQMzSgwmvopKxSoADecBFpCEyjt2MCo/Ec0ovg5Uu3/d8amc0TfSd1u2ZSt9oSg1K282beq36BrGaTLOkEAiy33DdQIRt/f36z9QWJz0UacVYC+zfm4gFfjtEygKoIZcpjyLba/JZuoup+UBBhkRr98cmm7bN+0z8V0arh2HPg6jkNFhmW9HXvf68c5Q0kITVvUSSki+vv0OITj7MQmfAEaUS1xYa00Vmam75grQYEFObAYSrWnggFDmzyuREjwke4WupIq/EtpUPDU8l3MCwRQU3Q1V7r+SAdQ3XOQJ/p5JS7QT6PjgD0/zMzYMHVyySUtESzu16si7IYBBbbxJTkgu1yitoDg1ge2912PXguPs9hcovTWr47Em0HuQhLf7cs7L3oWN62Jlw9mSeoZPoYvcQksQbIVzUXBJATnTHHAtp0X5CKwf8i3zr81YQoUOCRFeo5GFYwzJN8NzXZibKrj1Ey/wDyWhypjELK0wfHkzInRZMLCl3hedUUucbTeE/YVk03/KC+6Ryf6b34iKgftRE0qb5xiuG0I9LC0qUMKm/BfaF+T7xeA710UomxEtiomLRVzjK7yp42VAR07hgkiX/YWbE/q0yHpfMGf/tjgfHqGYA6a65x42CvTE5yyw8u6ofdtdghEk4mPtKD1k6UMgCzVqGSDMtmFFfpqEIr6hYbOTA66WvDhLOHlCyOJ3BJY+X9gdm9V3hS2hXmGvEiIRfvqMXijjI3L/Vx6D8XKRp2U3YW3/OtsnEy7izyshS1VxwIQlGrRBVwMwRC5VAIRjfV+8JcaqN+xJgsVGvYzl43+I09Hjgt8rWXgdStLj+WkmXQFbThSIInvG2QdQZulJswj1XL67ZJTi9knhpTCjUPU2yvpJuKErsCRFE7OSygIBvWoE3zCS1J+1b1QHgKmRWXUaVg87NSu3ipKhJVQWmp+HY21xW9jYlrQyJ1cCRvra2ScjPhK5orqksd9KhZTIa20xIkiijUSVQE+d27Qw6/r0y67yZgupzLcn3UxI0SXW9q73gl51frfegt0W7ssjztOo3ntsMpKXxN2LsH0EdSwOzVEbLE8nAIFbR/IyLfFl+TelMyNy3dskKB5/Y2SLEJcsH4SFMx/m4Qh6cjpcJJR7TrcyyDjN0r7Sp55HmLsa8XAhVN6zZH72YZ/ZNCgBf3oX2Gfa1BAZYKlPUjXllfO0MnXFvEYAB/0bFy1EOekpmevFxxc43oe+ha9VfGlF7BNqQSG1+yGv0IWodYcY8N+9Ur81WBnw547+5IUMIhn2QP/3WQZxGlkPHlF/nhQ0l4Kvdy6juJSyvst7hkXcYYnw38VHL+M35jhsDEYrC91dask3NOqNEPEuGzFHXr45KTRT4s+mS527LmaVpi1NqzTWcLP5iPjeDmwARk/VjwjuD5VdUxSZ4ZpLcnd0fVGd8aXWQKtk2lpWCSdO78eDlEFjFYiL9FLtOzXuKHJ4v8vMYdOugEnW9obUOB8Ai5qgLeSysjFgdDf7JJAZzSkGAwIyeMB/f5V1R4Gb4+Xgxq6U90Wd0sRIKYNd9e6mQbhuyRtbE9ukC4ebCGxNz5ll/Et7JPkqyUmvJdTSeNwVU+hgukynpDCnUhpiLo4tnDqHAz0WPC5OHhczP7aAgw66adpg4HI40rGISHSv7n24ye4wvpmy8ZRzbLCEI0OllHzkjeBHsDp+HgO9Qd+gF/j+LfP08DEvAh35+N47ZLaAx1U7jMrAAAAAQAFWC41MDkAAASsMIIEqDCCApACCQC46bqx4aGN7zANBgkqhkiG9w0BAQsFADAWMRQwEgYDVQQDDAtZT1VSX0NMSUVOVDAeFw0yMTAyMDIxNDU2MThaFw0yMzAyMDIxNDU2MThaMBYxFDASBgNVBAMMC1lPVVJfQ0xJRU5UMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEArVOy1GwHNQ/Ad0aAffWEwFjJyIIlyc/XTdJQ0RThBP0p0iE1HrTIj9/7U/3wuadXdXp8qodev8XHfc4py7VW8+a+ZDP/oM0Fer+Guos8zDCrHy4ARJUYUlwWSIzqkGMQhPkik+WctEbpHm/j+6lahNNXhzMXFIWg6qwvx6t1cgd5IPuwOpDuR4vi2GCjEGqT+UmaWE7pAoF4mDtBj+NgFwKWWWiQNKbYQlGaLMZ3v5+VQnBAdrLVxaLeLzzKTYpIMFGbgrv9OPhU+n8BIKDDM6+TA9acM0stJOt8jqT1Fyc35M6Fe9T6cOZ3Z+WeTGLafY6FzseoFUw6BAaliW6/xDccVz3h5TzSPTQ+fD9gPHyAXmZf3QjlKAdeAUuwza1Kos5jDkrjlDPD6y/hX4NqRsdb7MStuD5mEnOMxEAmfiwOhC+yav2/9jigSMOT9/A4D/L5dazWaUOSAXx2yGcUKVmjfXzSUnLjcH2rYQ4OiFUAYDJzpgOWz6/iTUD9CPEuHX8x9S2DO4DMbu8CkKcexquH6CmDZmH3Oj8+/gfs3YUnBa2shsT+1QpXUV+eHOkr0vdW+bL4P5o2///kEGUGtlmHuHKwd5nIjBvsTUzpxLU/pouXN5JYtX6J4Ushc4rIulVcEG4IdJW2BH+leev7lHTJqxOU6y8pDQ9GN1TFFPECAwEAATANBgkqhkiG9w0BAQsFAAOCAgEAGWBwIvR2t+Ky1Y9fRzJk4cFgplym9h4Q11YMaQDxjDNqGkZhWrva67QCVVKEXSMxTsRldb5kch1ArJCZpEWQtxkIKc+xnn3Oja382BTSKFWAnhleXniecycOJSCD/W+YcfYF/fKRI0sC7FkJHZhAIJkbdyY1rrGKNaHjWFutNWlcw97JZlJmzX8aBZpLxb5txoV7Peod2Os78vuL5+nIL0VwDvjEkz8il/yF3YQNw0Mx70gaFhpxgYax4Qd6ga6CSlO1+afD2sfDySzWMCyT3kH19pKQAfJEOPYgVyPAfDp5O4AL3ef4ly75DLRx6ZyoDbrqxnKhODAAroK+zLz9T8rPZTxsc/oPcevFUig1slBReJ/oDuvR5TtN94+SyvkFS4FV91QLxuocUh5PKDtCj3g6FDh8QwprpdnGZiUosuy80o5S99NvDYGIL9SXcZSu41S4RjXTfTsq66Al012iw3ZjFIFBhu0G8fiH9PXCBNaofge3V31QBM08w3yAwJGYziWlZIoo74kWRp9SUvLN4LwOZRBiPk5e667fkcqAAIkNSFZhQCLDFWeo5BnftdP0w1HHIA6i1ttGFyT3Se2Of+/skJpVPN2Zc/jW1eZ2f+kuLFTJ0b+UDcwsK3HaXgIxMhu5OGmpUN0K4Dj1yh9irybE0RDVppdVOA7VbV3OZpzbpCZQlaOQhsbXn2DKdUmG5EvQ+A=="""
-                    privateKeystoreKey = "cGFzc3dvcmQ="
-                    certificateExpiryDate = 2021-08-07
+                    privateKeystorePath = null
+                    privateKeystoreType = "JKS"
+
+                    //privateKeystore = null
+                    //privateKeystorePath = "conf/cert/certificate.p12"
+                    //privateKeystoreType = "pkcs12"
+
+                    privateKeystorePassword = "cGFzc3dvcmQ="
+                    certificateExpiryDate = 2025-08-07
                 }
 
                 authentication {
@@ -168,9 +174,10 @@ play.ws.ssl {
     keyManager = {
         stores = [
             {
-                type = "JKS"
-                data = ${microservice.services.birth-registration-matching.gro.tls.privateKeystore}
-                password = ${microservice.services.birth-registration-matching.gro.tls.privateKeystoreKey}
+                data     = ${microservice.services.birth-registration-matching.gro.tls.privateKeystore}
+                path     = ${microservice.services.birth-registration-matching.gro.tls.privateKeystorePath}
+                password = ${microservice.services.birth-registration-matching.gro.tls.privateKeystorePassword}
+                type     = ${microservice.services.birth-registration-matching.gro.tls.privateKeystoreType}
             }
         ]
     }


### PR DESCRIPTION
In order to get support for potential issues going forward we need to be providing the keystore via the new platform standard outlined here:
https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?pageId=859506931

Unfortunately we do not have access to the existing unencrypted values for the QA and Production config so we cannot migrate it, therefore we have to have both old and new ways be possible side by side (hence the use of null).
As such, the config has been refactored slightly so that we can use the new way in QA and the old in Prod until we are receive the new certs from the HO for Prod too. Then there will be a follow up ticket to remove the old handling and be fully migrated
This will require changes in app-config-production and app-config-qa which **must** be merged before this PR:
Prod - https://github.com/hmrc/app-config-production/pull/22397
QA - https://github.com/hmrc/app-config-qa/pull/22483